### PR TITLE
Remove duplicate FSharp references

### DIFF
--- a/Source/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.fsproj
+++ b/Source/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.fsproj
@@ -79,9 +79,6 @@
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.4.6.2\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/Samples/Registration.Sample.FSharp/Registration.Sample.FSharp.fsproj
+++ b/Source/Samples/Registration.Sample.FSharp/Registration.Sample.FSharp.fsproj
@@ -111,9 +111,6 @@
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core.4.6.2\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
The F# projects are currently not compiling due to multiple references to the `FSharp.Core` assembly.

![image](https://user-images.githubusercontent.com/177608/60760073-864d3c00-a005-11e9-9852-a3e7cbca6b26.png)

```
6>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2106,5): warning MSB3243: No way to resolve conflict between "FSharp.Core, Version=4.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". Choosing "FSharp.Core, Version=4.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" arbitrarily.
6>		Consider app.config remapping of assembly "FSharp.Core, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" from Version "4.4.0.0" [C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.0\FSharp.Core.dll] to Version "4.6.0.0" [C:\dev\excel-dna\Registration\Source\packages\FSharp.Core.4.6.2\lib\net45\FSharp.Core.dll] to solve conflict and get rid of warning.
6>FSC: error FS0215: Multiple references to 'FSharp.Core.dll' are not permitted
```

ps: This should resolve #23