### PR TITLE
Update all projects to target ExcelDna v1.1.0-beta2

### DIFF
--- a/NuGet/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.nuspec
+++ b/NuGet/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>ExcelDna.Registration.FSharp</id>
-        <version>1.1.0-beta1</version>
+        <version>1.1.0-beta2</version>
         <title>Excel-DNA Registration Extensions for F#</title>
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
@@ -14,11 +14,11 @@
         This package adds additional transformations appropriate to F# projects.</description>
         <summary>Excel-DNA Registration provides custom registration and function transformation helpers to Excel-DNA add-ins.</summary>
         <tags>excel exceldna udf excel-dna</tags>
-            <dependencies>
-      <dependency id="ExcelDna.Integration" version="[1.1.0-beta1]" />
-      <dependency id="ExcelDna.Registration" version="[1.1.0-beta1]" />
-      <dependency id="ExcelDna.Interop" version="14.0.0" />
-    </dependencies>
+        <dependencies>
+            <dependency id="ExcelDna.Integration" version="1.1.0-beta2" />
+            <dependency id="ExcelDna.Registration" version="1.1.0-beta2" />
+            <dependency id="ExcelDna.Interop" version="14.0.0" />
+        </dependencies>
     </metadata>
     <files>
         <file src="..\..\Source\ExcelDna.Registration.FSharp\bin\Release\ExcelDna.Registration.FSharp.dll" target="lib\net40\ExcelDna.Registration.FSharp.dll" />

--- a/NuGet/ExcelDna.Registration.VisualBasic/ExcelDna.Registration.VisualBasic.nuspec
+++ b/NuGet/ExcelDna.Registration.VisualBasic/ExcelDna.Registration.VisualBasic.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>ExcelDna.Registration.VisualBasic</id>
-        <version>1.1.0-beta1</version>
+        <version>1.1.0-beta2</version>
         <title>Excel-DNA Registration Extensions for Visual Basic</title>
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
@@ -14,11 +14,11 @@
         This package adds additional transformations appropriate to Visual Basic projects, enhancing VBA compatibility.</description>
         <summary>Excel-DNA Registration provides custom registration and function transformation helpers to Excel-DNA add-ins.</summary>
         <tags>excel exceldna udf excel-dna</tags>
-            <dependencies>
-      <dependency id="ExcelDna.Integration" version="[1.1.0-beta1]" />
-      <dependency id="ExcelDna.Registration" version="[1.1.0-beta1]" />
-      <dependency id="ExcelDna.Interop" version="14.0.0" />
-    </dependencies>
+        <dependencies>
+            <dependency id="ExcelDna.Integration" version="1.1.0-beta2" />
+            <dependency id="ExcelDna.Registration" version="1.1.0-beta2" />
+            <dependency id="ExcelDna.Interop" version="14.0.0" />
+        </dependencies>
     </metadata>
     <files>
         <file src="..\..\Source\ExcelDna.Registration.VisualBasic\bin\Release\ExcelDna.Registration.VisualBasic.dll" target="lib\net40\ExcelDna.Registration.VisualBasic.dll" />

--- a/NuGet/ExcelDna.Registration/ExcelDna.Registration.nuspec
+++ b/NuGet/ExcelDna.Registration/ExcelDna.Registration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>ExcelDna.Registration</id>
-        <version>1.1.0-beta1</version>
+        <version>1.1.0-beta2</version>
         <title>Excel-DNA Registration Extensions</title>
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
@@ -13,9 +13,9 @@
         <description>Excel-DNA Registration is an enhancement for Excel-DNA.</description>
         <summary>Excel-DNA Registration provides custom registration and function transformation helpers to Excel-DNA add-ins.</summary>
         <tags>excel exceldna udf excel-dna</tags>
-            <dependencies>
-      <dependency id="ExcelDna.Integration" version="[1.1.0-beta1]" />
-    </dependencies>
+        <dependencies>
+          <dependency id="ExcelDna.Integration" version="1.1.0-beta2" />
+        </dependencies>
     </metadata>
     <files>
         <file src="..\..\Source\ExcelDna.Registration\bin\Release\ExcelDna.Registration.dll" target="lib\net40\ExcelDna.Registration.dll" />

--- a/Source/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.fsproj
+++ b/Source/ExcelDna.Registration.FSharp/ExcelDna.Registration.FSharp.fsproj
@@ -72,8 +72,8 @@
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core">

--- a/Source/ExcelDna.Registration.FSharp/packages.config
+++ b/Source/ExcelDna.Registration.FSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net45" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net45" />
   <package id="FSharp.Core" version="4.6.2" targetFramework="net45" />
 </packages>

--- a/Source/ExcelDna.Registration.VisualBasic/ExcelDna.Registration.VisualBasic.vbproj
+++ b/Source/ExcelDna.Registration.VisualBasic/ExcelDna.Registration.VisualBasic.vbproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Excel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">

--- a/Source/ExcelDna.Registration.VisualBasic/packages.config
+++ b/Source/ExcelDna.Registration.VisualBasic/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net40" />
   <package id="ExcelDna.Interop" version="14.0.1" targetFramework="net4" />
 </packages>

--- a/Source/ExcelDna.Registration/ExcelDna.Registration.csproj
+++ b/Source/ExcelDna.Registration/ExcelDna.Registration.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Source/ExcelDna.Registration/packages.config
+++ b/Source/ExcelDna.Registration/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net40" />
 </packages>

--- a/Source/Samples/Registration.Sample.FSharp/Registration.Sample.FSharp.fsproj
+++ b/Source/Samples/Registration.Sample.FSharp/Registration.Sample.FSharp.fsproj
@@ -104,9 +104,9 @@
     <None Include="Properties\ExcelDna.Build.props" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core.4.6.2\lib\net45\FSharp.Core.dll</HintPath>
@@ -126,12 +126,12 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" />
+  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets'))" />
+    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Samples/Registration.Sample.FSharp/packages.config
+++ b/Source/Samples/Registration.Sample.FSharp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="1.1.0-beta1" targetFramework="net45" developmentDependency="true" />
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net45" />
+  <package id="ExcelDna.AddIn" version="1.1.0-beta2" targetFramework="net45" developmentDependency="true" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net45" />
   <package id="FSharp.Core" version="4.6.2" targetFramework="net45" />
 </packages>

--- a/Source/Samples/Registration.Sample.VisualBasic/Registration.Sample.VisualBasic.vbproj
+++ b/Source/Samples/Registration.Sample.VisualBasic/Registration.Sample.VisualBasic.vbproj
@@ -50,8 +50,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Excel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -152,12 +152,12 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" />
+  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets'))" />
+    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Samples/Registration.Sample.VisualBasic/packages.config
+++ b/Source/Samples/Registration.Sample.VisualBasic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="1.1.0-beta1" targetFramework="net451" developmentDependency="true" />
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net451" />
+  <package id="ExcelDna.AddIn" version="1.1.0-beta2" targetFramework="net451" developmentDependency="true" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net451" />
   <package id="ExcelDna.Interop" version="14.0.1" targetFramework="net451" />
 </packages>

--- a/Source/Samples/Registration.Sample/Registration.Sample.csproj
+++ b/Source/Samples/Registration.Sample/Registration.Sample.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -89,12 +89,12 @@ xcopy "$(SolutionDir)\packages\Excel-DNA.0.32.0-rc3-1\tools\ExcelDna64.xll" "$(T
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" />
+  <Import Project="..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets" Condition="Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta1\build\ExcelDna.AddIn.targets'))" />
+    <Error Condition="!Exists('..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ExcelDna.AddIn.1.1.0-beta2\build\ExcelDna.AddIn.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Samples/Registration.Sample/packages.config
+++ b/Source/Samples/Registration.Sample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="1.1.0-beta1" targetFramework="net451" developmentDependency="true" />
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net451" />
+  <package id="ExcelDna.AddIn" version="1.1.0-beta2" targetFramework="net451" developmentDependency="true" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net451" />
 </packages>

--- a/Source/Test/Registration.Test.csproj
+++ b/Source/Test/Registration.Test.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta1\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\packages\ExcelDna.Integration.1.1.0-beta2\lib\ExcelDna.Integration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Source/Test/packages.config
+++ b/Source/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.Integration" version="1.1.0-beta1" targetFramework="net451" />
+  <package id="ExcelDna.Integration" version="1.1.0-beta2" targetFramework="net451" />
   <package id="NUnit" version="3.7.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
ExcelDna.Registration `v1.1.0-beta1` is pinned to ExcelDna.Integration `v1.1.0-beta1` which blocks projects that use ExcelDna.Registration from upgrading to ExcelDna.AddIn `v1.1.0-beta2`

![image](https://user-images.githubusercontent.com/177608/83610796-65170780-a556-11ea-8f10-241afa36657c.png)

This PR changes the dependency to `v1.1.0-beta2+` (_not_ pinned) to resolve this issue